### PR TITLE
Don't allow rounding modes Up or Ceil

### DIFF
--- a/round.go
+++ b/round.go
@@ -30,17 +30,6 @@ func roundDown(n, l *big.Int) {
 	}
 }
 
-func roundCeil(n, l *big.Int) {
-	li := l.Int64()
-	if n.Sign() > 0 {
-		if li != 0 {
-			n.Add(n, l.SetInt64(10-li))
-		}
-	} else {
-		n.Add(n, l)
-	}
-}
-
 func roundFloor(n, l *big.Int) {
 	if n.Sign() > 0 {
 		n.Sub(n, l)
@@ -86,14 +75,8 @@ func roundHalfEven(n, l *big.Int) {
 }
 
 var (
-	// Up rounds away from zero.
-	Up RoundingMode = roundUp
-
 	// Down rounds towards zero.
 	Down RoundingMode = roundDown
-
-	// Ceil rounds towards positive infinity.
-	Ceil RoundingMode = roundCeil
 
 	// Floor rounds towards negative infinity.
 	Floor RoundingMode = roundFloor

--- a/round_test.go
+++ b/round_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestRoundUp(t *testing.T) {
-	m := Up
+	m := roundUp
 	testRounding(t, "5.5", "6", 0, m)
 	testRounding(t, "2.5", "3", 0, m)
 	testRounding(t, "1.6", "2", 0, m)
@@ -26,20 +26,6 @@ func TestRoundDown(t *testing.T) {
 	testRounding(t, "2.5", "2", 0, m)
 	testRounding(t, "1.6", "1", 0, m)
 	testRounding(t, "1.1", "1", 0, m)
-	testRounding(t, "1.0", "1", 0, m)
-	testRounding(t, "-1.0", "-1", 0, m)
-	testRounding(t, "-1.1", "-1", 0, m)
-	testRounding(t, "-1.6", "-1", 0, m)
-	testRounding(t, "-2.5", "-2", 0, m)
-	testRounding(t, "-5.5", "-5", 0, m)
-}
-
-func TestRoundCeil(t *testing.T) {
-	m := Ceil
-	testRounding(t, "5.5", "6", 0, m)
-	testRounding(t, "2.5", "3", 0, m)
-	testRounding(t, "1.6", "2", 0, m)
-	testRounding(t, "1.1", "2", 0, m)
 	testRounding(t, "1.0", "1", 0, m)
 	testRounding(t, "-1.0", "-1", 0, m)
 	testRounding(t, "-1.1", "-1", 0, m)
@@ -117,7 +103,7 @@ func testRounding(t *testing.T, a, b string, prec int, method RoundingMode) {
 }
 
 func BenchmarkRoundUp(b *testing.B) {
-	benchmarkRounding(b, Up)
+	benchmarkRounding(b, roundUp)
 }
 
 func BenchmarkRoundHalfEven(b *testing.B) {


### PR DESCRIPTION
With the current implementation, `Round(big.NewRat(1, 100), 0, [Ceil|Up])` evaluates to 0, not 1. As such, we should not allow those rounding modes to be used. I opened https://github.com/wadey/go-rounding/issues/1 upstream.